### PR TITLE
Fix API healthcheck path

### DIFF
--- a/apps/api/healthcheck.sh
+++ b/apps/api/healthcheck.sh
@@ -2,7 +2,7 @@
 # healthcheck.sh
 
 # Try to hit your app’s health endpoint
-if curl --fail http://localhost:3000/healthz >/dev/null 2>&1; then
+if curl --fail http://localhost:3000/health >/dev/null 2>&1; then
   exit 0
 else
   exit 1


### PR DESCRIPTION
## Summary
- point healthcheck script to `/health`

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68421110b0fc83299453964a20753a2b