### PR TITLE
Fix ScraperAPI env var name

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This version proxies all HTTP requests through [ScraperAPI](https://www.scrapera
 
 1. **Set your ScraperAPI key** in `.env`:
    ```
-   SCRAPERAPI_KEY=your_scraperapi_key_here
+   SCRAPER_API_KEY=your_scraperapi_key_here
    ```
 
 2. **Axios is configured automatically** via an interceptor in `apps/api/src/index.js`.


### PR DESCRIPTION
## Summary
- fix README to use `SCRAPER_API_KEY`

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_6842111a0d5883299211d6181fe8cf56