### PR TITLE
Fix aggregate input handling

### DIFF
--- a/apps/api/src/parsers/anywho.js
+++ b/apps/api/src/parsers/anywho.js
@@ -5,9 +5,8 @@ export const modes = ['PHONE', 'NAME', 'ADDR'];
 
 /**
  * Build the AnyWho search URL.
- * Accepts either:
- *   - a string (the raw query), or
- *   - an object { query, firstName, lastName }
+ *
+ * @param {object} input - `{ query, firstName, lastName }`
  */
 export function urlBuilder(input) {
   const value =


### PR DESCRIPTION
## Summary
- normalize inputs in aggregate() to always pass an object to parsers
- document aggregate() parameter expectations
- document input type for AnyWho urlBuilder

## Testing
- `npm test --silent` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_6842111fff188329b341dede210cf493