### PR TITLE
Add vitest coverage for parsers, queue and AI

### DIFF
--- a/apps/api/test/processWithAI.test.js
+++ b/apps/api/test/processWithAI.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+vi.mock('openai', () => {
+  return {
+    default: class {
+      chat = { completions: { create: vi.fn().mockResolvedValue({
+        choices: [{ message: { content: 'AIRESULT' } }]
+      }) } };
+    }
+  };
+});
+
+import { organizeAndRate } from '../src/processWithAI.js';
+
+describe('organizeAndRate', () => {
+  let tmpDir;
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ai-'));
+  });
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('writes AI-organized results to file', async () => {
+    const rawPath = path.join(tmpDir, 'raw.json');
+    const outPath = path.join(tmpDir, 'out.json');
+    await fs.writeFile(rawPath, JSON.stringify([{ parser: 'p', data: {} }]), 'utf-8');
+    const full = await organizeAndRate(rawPath, outPath);
+    expect(full).toBe(path.resolve(process.cwd(), outPath));
+    const txt = await fs.readFile(full, 'utf-8');
+    expect(txt).toBe('AIRESULT');
+  });
+});

--- a/apps/api/test/queue.test.js
+++ b/apps/api/test/queue.test.js
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { setTimeout } from 'timers/promises';
+
+async function loadQueue(concurrency) {
+  process.env.QUEUE_CONCURRENCY = String(concurrency);
+  vi.resetModules();
+  return (await import('../src/services/queue.js')).createQueue;
+}
+
+describe('createQueue', () => {
+  afterEach(() => {
+    delete process.env.QUEUE_CONCURRENCY;
+    vi.resetModules();
+  });
+
+  it('runs tasks sequentially when concurrency is 1', async () => {
+    const createQueue = await loadQueue(1);
+    const order = [];
+    const q = createQueue();
+    q.push(async () => { order.push('a'); await setTimeout(10); return 'x'; });
+    q.push(async () => { order.push('b'); return 'y'; });
+    const results = await q.runAll();
+    expect(results).toEqual(['x','y']);
+    expect(order).toEqual(['a','b']);
+  });
+});

--- a/apps/api/test/runAllParsers.test.js
+++ b/apps/api/test/runAllParsers.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+vi.mock('../src/parsers/index.js', () => ({
+  getParsersForMode: vi.fn(),
+}));
+vi.mock('axios');
+
+import { getParsersForMode } from '../src/parsers/index.js';
+import axios from 'axios';
+import { aggregate } from '../src/runAllParsers.js';
+
+describe('aggregate', () => {
+  let tmpDir;
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agg-'));
+  });
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('runs parsers and writes aggregated results', async () => {
+    function url1() { return 'http://one'; }
+    const parser1 = { urlBuilder: url1, parse: vi.fn().mockResolvedValue('A') };
+    function url2() { return 'http://two'; }
+    const parser2 = { urlBuilder: url2, parse: vi.fn().mockResolvedValue('B') };
+    getParsersForMode.mockReturnValue([parser1, parser2]);
+    axios.get.mockResolvedValue({ data: '<html>' });
+
+    const outFile = path.join(tmpDir, 'out.json');
+    const full = await aggregate('PHONE', { query: 'x' }, outFile);
+
+    expect(full).toBe(path.resolve(process.cwd(), outFile));
+    const data = JSON.parse(await fs.readFile(full, 'utf-8'));
+    expect(data).toEqual([
+      { parser: 'url1', data: 'A' },
+      { parser: 'url2', data: 'B' }
+    ]);
+    expect(axios.get).toHaveBeenCalledTimes(2);
+    expect(parser1.parse).toHaveBeenCalled();
+    expect(parser2.parse).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for `aggregate()` using mocked parsers and Axios
- add tests for `createQueue()` with concurrency 1
- add tests for `organizeAndRate()` mocking OpenAI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846204d8f408329813456e5a27bd119