### PR TITLE
Fix env error and add manual test UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,6 @@ REDIS_URL=redis://user:pass@host:port/0
 3. Parsers:
    - Updated stubs in `apps/api/src/parsers`
    - Dispatch in `parsers/index.js`
+
+## Local Testing Frontend
+A simple HTML page is available at `apps/api/public/test.html` for manually calling the `/run` endpoint. Start the API with the required environment variables and open the page in your browser to submit queries and view the raw response.

--- a/apps/api/public/test.html
+++ b/apps/api/public/test.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Function Tester</title>
+  <style>
+    body{font-family:sans-serif;margin:20px;}
+    label{display:block;margin-top:10px;}
+    pre{background:#f0f0f0;border:1px solid #ccc;padding:10px;min-height:200px;}
+  </style>
+</head>
+<body>
+  <h1>API Function Tester</h1>
+  <label>Mode:
+    <select id="mode">
+      <option value="PHONE">PHONE</option>
+      <option value="NAME">NAME</option>
+      <option value="ADDR">ADDR</option>
+    </select>
+  </label>
+  <label>Query:
+    <input id="query" placeholder="Enter query" style="width:300px;">
+  </label>
+  <button id="run">Run</button>
+  <pre id="output"></pre>
+
+  <script>
+  document.getElementById('run').onclick = async () => {
+    const mode = document.getElementById('mode').value;
+    const q = document.getElementById('query').value.trim();
+    const out = document.getElementById('output');
+    if(!q){ out.textContent = 'Enter a query'; return; }
+    try{
+      const res = await fetch('/run', {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({mode, query:{query:q}})
+      });
+      const text = await res.text();
+      out.textContent = text;
+    }catch(err){
+      out.textContent = 'Error: ' + err;
+    }
+  };
+  </script>
+</body>
+</html>

--- a/apps/api/src/processWithAI.js
+++ b/apps/api/src/processWithAI.js
@@ -2,7 +2,18 @@ import fs from 'fs/promises';
 import OpenAI from 'openai';
 import path from 'path';
 import 'dotenv/config';
-const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+let openai;
+function getOpenAI() {
+  if (!openai) {
+    const key = process.env.OPENAI_API_KEY;
+    if (!key) {
+      throw new Error('OPENAI_API_KEY env var not set');
+    }
+    openai = new OpenAI({ apiKey: key });
+  }
+  return openai;
+}
 
 /**
  * Organize raw parser results with AI and output ranked JSON.
@@ -28,7 +39,7 @@ ${JSON.stringify(rawJson, null, 2)}
   ...
 ]
 `;
-  const response = await openai.chat.completions.create({
+  const response = await getOpenAI().chat.completions.create({
     model: "gpt-4o-mini",
     messages: [{ role: "system", content: prompt }],
     temperature: 0

--- a/apps/api/test/processWithAI.test.js
+++ b/apps/api/test/processWithAI.test.js
@@ -13,6 +13,8 @@ vi.mock('openai', () => {
   };
 });
 
+process.env.OPENAI_API_KEY = 'test';
+
 import { organizeAndRate } from '../src/processWithAI.js';
 
 describe('organizeAndRate', () => {


### PR DESCRIPTION
## Summary
- allow running API without `OPENAI_API_KEY` until `/run` is invoked
- add simple `test.html` page for manually calling the API
- document testing page in README
- update tests for new env handling

## Testing
- `npm test --workspace=apps/api`

------
https://chatgpt.com/codex/tasks/task_e_6847db73ee2483298c0ca91efdf7b228