### PR TITLE
Enhance frontend search UI

### DIFF
--- a/apps/frontend/src/App.css
+++ b/apps/frontend/src/App.css
@@ -7,33 +7,28 @@ body {
   font-family: sans-serif;
 }
 
+
 .dashboard {
-  display: grid;
-  grid-template-columns: 200px 1fr;
+  display: flex;
+  flex-direction: column;
   height: 100vh;
 }
 
-.sidebar {
+header {
   background: #2c3e50;
   color: #ecf0f1;
   padding: 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
-.mode-btn {
-  display: block;
-  width: 100%;
-  margin: 10px 0;
-  padding: 10px;
-  background: #34495e;
-  border: none;
-  color: #ecf0f1;
-  border-radius: 4px;
-  cursor: pointer;
+.status.live {
+  color: #2ecc71;
 }
 
-.mode-btn.active,
-.mode-btn:hover {
-  background: #2980b9;
+.status.dead {
+  color: #e74c3c;
 }
 
 .main {
@@ -62,6 +57,11 @@ body {
   color: #fff;
   border-radius: 0 4px 4px 0;
   cursor: pointer;
+}
+
+.timer {
+  margin-bottom: 10px;
+  color: #555;
 }
 
 #result {


### PR DESCRIPTION
## Summary
- overhaul React interface to use single search input
- show connection status and request timer
- simplify layout and styles

## Testing
- `npm -w apps/frontend run lint`
- `npm -w apps/api test`


------
https://chatgpt.com/codex/tasks/task_e_6847e2cb263083298cb07d0fa4071721